### PR TITLE
[MDL-39][MDL-47] Page API 개선 및 기능 추가

### DIFF
--- a/backend/pkg/apis/page/handler.go
+++ b/backend/pkg/apis/page/handler.go
@@ -35,7 +35,9 @@ func (ph *handler) createUserPage(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("user_id")
 
 	page := &models.Page{
-		ID: uuid.New(),
+		ID:            uuid.New(),
+		NodeNum:       0,
+		ConnectionNum: 0,
 	}
 	if err := json.NewDecoder(r.Body).Decode(page); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -155,6 +157,9 @@ func (ph *handler) updateUserPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
+
+	page.NodeNum = len(page.Nodes)
+	page.ConnectionNum = len(page.Connections)
 
 	f, err = os.OpenFile(pageFilePath, os.O_WRONLY|os.O_TRUNC, 0755)
 	if err != nil {

--- a/backend/pkg/apis/page/handler.go
+++ b/backend/pkg/apis/page/handler.go
@@ -27,6 +27,7 @@ func (ph *handler) RegsistRoute(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/users/{user_id}/pages", ph.listUserPages)
 	mux.HandleFunc("GET /api/users/{user_id}/pages/{page_id}", ph.loadUserPage)
 	mux.HandleFunc("PUT /api/users/{user_id}/pages/{page_id}", ph.updateUserPage)
+	mux.HandleFunc("DELETE /api/users/{user_id}/pages/{page_id}", ph.deleteUserPage)
 }
 
 const dataDir string = "data"
@@ -172,7 +173,28 @@ func (ph *handler) updateUserPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := respUpdateUserPage{
+	response := respModifyUserPage{
+		SuccessOK: true,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
+func (ph *handler) deleteUserPage(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("user_id")
+	pageID := r.PathValue("page_id")
+	ph.log.Info("Delete user page", "User", userID, "PageID", pageID)
+
+	filePath := filepath.Join(dataDir, userID, pageID+".json")
+	if err := os.Remove(filePath); err != nil {
+		http.Error(w, "failed to remove file", http.StatusBadRequest)
+		return
+	}
+
+	response := respModifyUserPage{
 		SuccessOK: true,
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/backend/pkg/apis/page/response.go
+++ b/backend/pkg/apis/page/response.go
@@ -14,7 +14,7 @@ type respUserPage struct {
 
 type respListUserPages []respUserPage
 
-type respUpdateUserPage struct {
+type respModifyUserPage struct {
 	SuccessOK bool `json:"success_ok"`
 }
 

--- a/backend/pkg/apis/page/response.go
+++ b/backend/pkg/apis/page/response.go
@@ -6,8 +6,10 @@ import (
 )
 
 type respUserPage struct {
-	ID   uuid.UUID `json:"id"`
-	Name string    `json:"name"`
+	ID            uuid.UUID `json:"id"`
+	Name          string    `json:"name"`
+	NodeNum       int       `json:"nodeNum"`
+	ConnectionNum int       `json:"connectionNum"`
 }
 
 type respListUserPages []respUserPage
@@ -18,7 +20,9 @@ type respUpdateUserPage struct {
 
 func convertPageIntoResp(page *models.Page) respUserPage {
 	return respUserPage{
-		ID:   page.ID,
-		Name: page.Name,
+		ID:            page.ID,
+		Name:          page.Name,
+		NodeNum:       page.NodeNum,
+		ConnectionNum: page.ConnectionNum,
 	}
 }

--- a/backend/pkg/models/page.go
+++ b/backend/pkg/models/page.go
@@ -3,10 +3,12 @@ package models
 import "github.com/google/uuid"
 
 type Page struct {
-	ID          uuid.UUID    `json:"id"`
-	Name        string       `json:"name"`
-	Nodes       []Node       `json:"nodes,omitempty"`
-	Connections []Connection `json:"connections,omitempty"`
+	ID            uuid.UUID    `json:"id"`
+	Name          string       `json:"name"`
+	Nodes         []Node       `json:"nodes,omitempty"`
+	Connections   []Connection `json:"connections,omitempty"`
+	NodeNum       int          `json:"nodeNum"`
+	ConnectionNum int          `json:"connectionNum"`
 }
 
 type Node struct {

--- a/backend/pkg/server/config.go
+++ b/backend/pkg/server/config.go
@@ -14,7 +14,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Port:     "8080",
-		RootPath: "wwwroot",
+		RootPath: "static",
 	}
 }
 


### PR DESCRIPTION
- Page API nodeNum, connectionNum 필드 추가
- Delete Page API 추가

### 테스트
[PostMan](https://sky-puzzle.postman.co/workspace/sky-puzzle-Workspace~12ef4758-26bf-47d7-805f-e5eecb245412/overview)에서 Mindlink Collection 사용하여 API 전송 해보기
- nodeNum connectionNum 수치가 node개수와 connection개수가 잘 나오는지 생성, 수정, 조회 요청 보내보기

API 공유 문서
https://www.notion.so/API-bbcba5f5b40b40bcb5c3f606730fef8e

참고 이슈링크
https://www.notion.so/Page-Delete-API-3942df641a0f499d8b113f2cc754cd0d?pvs=4
https://www.notion.so/ID-133a40f8cf99807b8596c0ba5e803417?pvs=4