### PR TITLE
배포 시 리다이렉션 uri 이슈 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+FROM golang:1.23 AS builder
 
 ARG BUILD_FLAGS
 


### PR DESCRIPTION
- 로그인 시 리다이렉션 url이 http로 되어 있어 배포시에는 접근하지 못하던 버그
  - 개발시는 `http://localhost`로, prod에서는 `https://<domain>`으로 리다이렉션 되도록 코드 수정
- 수정 코드 0.2.1 이미지로 만들어서 배포, GCP에 띄우고 로그인 정상 접속 확인
- Dockerfile 불필요한 내용 삭제